### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/go-geolocation/security/code-scanning/1](https://github.com/RumenDamyanov/go-geolocation/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided steps, the workflow interacts with repository contents (e.g., checking out code) and uploads coverage reports to Codecov. Therefore, we will set `contents: read` and ensure no unnecessary write permissions are granted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
